### PR TITLE
property actions

### DIFF
--- a/src/components/BIMDataGuidedTour.vue
+++ b/src/components/BIMDataGuidedTour.vue
@@ -191,16 +191,9 @@ export default {
           return;
         }
 
-        if (step.actions) {
-          step.actions?.projectViewSetter(
-            parseInt(
-              document
-                .querySelector("[data-guide-click=dashboard-project]")
-                .getAttribute("data-guide-projectid"),
-              10
-            )
-          );
-        }
+        step.action?.(
+          this.currentTarget.element.getAttribute("data-guide-param")
+        );
 
         if (step.clickable) {
           this.clickListener();

--- a/src/components/BIMDataGuidedTour.vue
+++ b/src/components/BIMDataGuidedTour.vue
@@ -191,6 +191,17 @@ export default {
           return;
         }
 
+        if (step.actions) {
+          step.actions?.projectTabSetter(
+            parseInt(
+              document
+                .querySelector("[data-guide-click=dashboard-project]")
+                .getAttribute("data-guide-projectid"),
+              10
+            )
+          );
+        }
+
         if (step.clickable) {
           this.clickListener();
         }

--- a/src/components/BIMDataGuidedTour.vue
+++ b/src/components/BIMDataGuidedTour.vue
@@ -192,7 +192,7 @@ export default {
         }
 
         if (step.actions) {
-          step.actions?.projectTabSetter(
+          step.actions?.projectViewSetter(
             parseInt(
               document
                 .querySelector("[data-guide-click=dashboard-project]")


### PR DESCRIPTION
hello team,

Here is a new implementation -> actions
It's a property that can be added into steps filled with "actionnable". 
It serves the currentStep which is played in the guided-tour.

The code below (in platform) is directly related to the code in the PR. it will be pushed afterwards

```js
actions: {
   projectViewSetter: projectId => {
      projectView.set(projectId, DEFAULT_PROJECT_VIEW);
   }
}
```

Paul